### PR TITLE
Add android device type detection

### DIFF
--- a/Assets/AirConsole/scripts/Runtime/AirConsole.cs
+++ b/Assets/AirConsole/scripts/Runtime/AirConsole.cs
@@ -29,6 +29,26 @@ namespace NDream.AirConsole {
         ResizeCameraAndReferenceResolution
     }
 
+    /// <summary>
+    /// Describes the type of Android device the game is running on.
+    /// </summary>
+    public enum AndroidDeviceType {
+        /// <summary>
+        /// Generic Android device without special UI mode.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// Android TV device.
+        /// </summary>
+        TV,
+
+        /// <summary>
+        /// Android Automotive device.
+        /// </summary>
+        Automotive
+    }
+
     public delegate void OnReady(string code);
 
     public delegate void OnMessage(int from, JToken data);
@@ -2197,6 +2217,30 @@ namespace NDream.AirConsole {
                 return false;
             }
             return _androidDataProvider.IsTvDevice();
+        }
+
+        // ReSharper disable once UnusedMember.Global
+        /// <summary>
+        /// Retrieves the type of Android device this game is running on.
+        /// </summary>
+        /// <remarks>
+        /// Returns <see cref="AndroidDeviceType.Normal"/> when the runtime is not Android
+        /// or when no specialized mode could be detected.
+        /// </remarks>
+        public AndroidDeviceType GetAndroidDeviceType() {
+            if (!IsAndroidRuntime || _androidDataProvider == null) {
+                return AndroidDeviceType.Normal;
+            }
+
+            if (_androidDataProvider.IsAutomotiveDevice()) {
+                return AndroidDeviceType.Automotive;
+            }
+
+            if (_androidDataProvider.IsTvDevice()) {
+                return AndroidDeviceType.TV;
+            }
+
+            return AndroidDeviceType.Normal;
         }
 
         private static float GetFloatFromMessage(JObject msg, string name, int defaultValue) =>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are more examples on the website: <http://developers.airconsole.com/#/guid
 
 # Platforms
 
-AirConsole supports WebGL and AndroidTV as targets. To make use of this plugin, you need to make sure to switch your target to either WebGL or Android.
+AirConsole supports WebGL, Android TV and Android Automotive as targets. To make use of this plugin, you need to make sure to switch your target to either WebGL or Android. Use `GetAndroidDeviceType()` to adapt your game for the detected device type.
 
 # Support
 


### PR DESCRIPTION
## Summary
- add `AndroidDeviceType` enum to categorize device type
- expose `GetAndroidDeviceType()` API
- document device type detection in README

## Testing
- `pnpm -r install --frozen-lockfile`

------
https://chatgpt.com/codex/tasks/task_b_6867e32474e8832b81f95749570a3b3b